### PR TITLE
remove orphaned cosaves on startup

### DIFF
--- a/EngineFixes64.ini
+++ b/EngineFixes64.ini
@@ -73,3 +73,9 @@ enabled=true
 ; disabled by default since you should only need it in some rare cases..
 [PrecacheKiller]
 enabled=false
+
+; terrible code that likely needs to be rewritten
+; deletes leftover SKSE64 cosaves that are not removed when the matching save is removed
+; disabled by default because it's likely really buggy - enable if you want to live on the edge
+[killOrphanedCosave]
+enabled=false

--- a/config.cpp
+++ b/config.cpp
@@ -49,6 +49,11 @@ namespace config
 	// disabled by default since most people should't need it
 	bool patchPrecacheKiller = false;
 	
+	// terrible code that likely needs to be rewritten
+	// deletes leftover SKSE64 cosaves that are not removed when the matching save is removed
+	// disabled by default because it's likely really buggy - enable if you want to live on the edge
+	bool killOrphanedCosave = false
+
 	bool LoadConfig(const std::string& path)
 	{
 		CSimpleIniA ini;
@@ -77,7 +82,7 @@ namespace config
 		patchSnowSparkle = ini.GetBoolValue("SnowSparkle", "enabled", true);
 		patchSaveAddedSoundCategories = ini.GetBoolValue("SaveAddedSoundCategories", "enabled", true);
 		patchPrecacheKiller = ini.GetBoolValue("PrecacheKiller", "enabled", false);
-
+		killOrphanedCosave = ini.GetBoolValue("killOrphanedCosave", "enabled", false);
 		return true;
 	}
 }	

--- a/config.h
+++ b/config.h
@@ -41,5 +41,8 @@ namespace config
 	// chargen precache disable
 	extern bool patchPrecacheKiller;
 
+	// likely buggy code to kill orphaned SKSE64 cosaves
+	extern bool killOrphanedCosave;
+
 	bool LoadConfig(const std::string& path);
 }


### PR DESCRIPTION
this is really ugly and to be honest may not even compile - I couldn't get the base engine fixes to compile on my machine so this hasn't _actually_ been _tested_ or anything. It _should_ work but no guarantees and I'd keep it disabled by default until the more adventurous folk have found all the bugs. Anyway, this shouldn't ever need to be ported or anything if a new version of skyrim comes out since it's all handled in the engine fix plugin itself. Anyway, have fun fixing up my spaghetti code!
