### PR TITLE
add music overlap fix

### DIFF
--- a/EngineFixes.toml
+++ b/EngineFixes.toml
@@ -40,6 +40,7 @@ GHeapLeakDetectionCrash = true          # Fix a crash where scaleform attempts t
 GlobalTime = true                       # Fixes game systems that are affected by game time instead of real time
 LipSync = true                          # Fix a bug causing lip sync to desync. Same as LE bug fix.
 MemoryAccessErrors = true               # Fix a handful of out-of-bounds or use-after-free bugs. Required for experimental memory patches.
+MusicOverlap = true                     # Fix a bug where multiple music track is playing at the same time
 MO5STypo = true                         # Fix a typo preventing the game from loading MO5S (1st person female alternate texture set) entries in ARMA forms
 NullProcessCrash = true                 # Fix a couple cases where the game can crash when checking the equipped weapons of an actor without an AI process
 PerkFragmentIsRunning = true            # Fix crash if the IsRunning function of a Perk Fragment is called on a non-Actor form

--- a/src/config.h
+++ b/src/config.h
@@ -50,6 +50,7 @@ public:
     static inline bSetting fixGlobalTime{ "Fixes", "GlobalTime", true };
     static inline bSetting fixLipSync{ "Fixes", "LipSync", true };
     static inline bSetting fixMemoryAccessErrors{ "Fixes", "MemoryAccessErrors", true };
+    static inline bSetting fixMusicOverlap{ "Fixes", "MusicOverlap", true };
     static inline bSetting fixMO5STypo{ "Fixes", "MO5STypo", true };
     static inline bSetting fixNullProcessCrash{ "Fixes", "NullProcessCrash", true };
     static inline bSetting fixPerkFragmentIsRunning{ "Fixes", "PerkFragmentIsRunning", true };

--- a/src/fixes.cpp
+++ b/src/fixes.cpp
@@ -58,6 +58,9 @@ namespace fixes
         if (*config::fixMemoryAccessErrors)
             PatchMemoryAccessErrors();
 
+        if (*config::fixMusicOverlap)
+            PatchMusicOverlap();
+
         if (*config::fixMO5STypo)
             PatchMO5STypo();
 

--- a/src/fixes.h
+++ b/src/fixes.h
@@ -23,6 +23,7 @@ namespace fixes
     bool PatchGlobalTime();
     bool PatchLipSync();
     bool PatchMemoryAccessErrors();
+    bool PatchMusicOverlap();
     bool PatchMO5STypo();
     bool PatchNullProcessCrash();
     bool PatchPerkFragmentIsRunning();

--- a/src/fixes/miscfixes.cpp
+++ b/src/fixes/miscfixes.cpp
@@ -749,6 +749,26 @@ namespace fixes
         return true;
     }
 
+    class MusicOverlapPatch
+    {
+    public:
+        static void Install()
+        {
+            REL::Relocation<std::uintptr_t> target(REL::ID{ 20700 });
+            REL::safe_write(target.address() + 0x22, std::uint16_t(0x9090));
+        }
+    };
+
+    bool PatchMusicOverlap()
+    {
+        logger::trace("- music overlap fix -"sv);
+
+        MusicOverlapPatch::Install();
+
+        logger::trace("success"sv);
+        return true;
+    }
+
     class MO5STypoPatch
     {
     public:


### PR DESCRIPTION
This is a well known bug in Skyrim, where sometimes there is multiple music is playing at the same time.
It happens when a `BSIMusicType` is in a state of `kFinishing`, but it wants to start up again before it begins to fade out. In this case an another music will be playing on top of the previous one, and the first music will never fade out, it will play until it ends. Most commonly happens with combat music.

Easiest way to reproduce:
- Spawn an enemy
- Wait for combat music to start
- Kill the enemy, and wait a second or two (so the state can change to `kFinishing`)
- Spawn an another enemy, before the first music starts to fade out.
If timed correctly this should produce multiple combat music playing at the same time.

The patched location here is in the function `BSMusicManager::ProcessEvent`. Definition of this class is in this pull request: https://github.com/Ryan-rsm-McKenzie/CommonLibSSE/pull/67
I changed a check for the flag `kDucksCurrentTrack` to `kAbruptTransition` as from the context it looks like it should be set to that. While this fixed the problem, I can't confirm that this is the exact cause, and not just a coincidence that will have side-effects elsewhere. I found no problems with it so far though.

Relevant functions:
`BSMusicManager::ProcessEvent` is at id `87937`.
Another possibly relevant one is at `87936`.