### PR TITLE
Add combat dialogue fix

### DIFF
--- a/EngineFixes.toml
+++ b/EngineFixes.toml
@@ -31,6 +31,7 @@ BSLightingShaderParallaxBug = true      # Fixes a bug causing the parallax techn
 BSTempEffectNiRTTI = true               # Fixes a bug where the NiRTTI for this object is not set properly
 CalendarSkipping = true                 # Fix a bug where the game calendar effectively skips a year if you fast travel too far between 20:00 and 23:99 in-game
 CellInit = true                         # Fixes a rare crash where a form does not get converted from an id to a pointer
+CombatDialogue = true                   # Fix a bug that causes the NPCs to use LostToNormal dialogue instead of CombatToNormal after killing their target
 ConjurationEnchantAbsorbs = true        # Fix bug where spell absorption triggers on enchanted items using conjuration summons
 CreateArmorNodeNullptrCrash = true      # Fix typo that may cause a crash somewhere in CreateArmorNode
 DoublePerkApply = true                  # Fix NPC perks applying twice when you load a game

--- a/src/config.h
+++ b/src/config.h
@@ -42,6 +42,7 @@ public:
     static inline bSetting fixCalendarSkipping{ "Fixes", "CalendarSkipping", true };
     static inline bSetting fixCellInit{ "Fixes", "CellInit", true };
     static inline bSetting fixCreateArmorNodeNullptrCrash{ "Fixes", "CreateArmorNodeNullptrCrash", true };
+    static inline bSetting fixCombatDialogue{ "Fixes", "CombatDialogue", true };
     static inline bSetting fixConjurationEnchantAbsorbs{ "Fixes", "ConjurationEnchantAbsorbs", true };
     static inline bSetting fixDoublePerkApply{ "Fixes", "DoublePerkApply", true };
     static inline bSetting fixEquipShoutEventSpam{ "Fixes", "EquipShoutEventSpam", true };

--- a/src/fixes.cpp
+++ b/src/fixes.cpp
@@ -34,6 +34,9 @@ namespace fixes
         if (*config::fixCreateArmorNodeNullptrCrash)
             PatchCreateArmorNodeNullptrCrash();
 
+        if (*config::fixCombatDialogue)
+            PatchCombatDialogue();
+
         if (*config::fixConjurationEnchantAbsorbs)
             PatchConjurationEnchantAbsorbs();
 

--- a/src/fixes.h
+++ b/src/fixes.h
@@ -14,6 +14,7 @@ namespace fixes
     bool PatchBSTempEffectNiRTTI();
     bool PatchCalendarSkipping();
     bool PatchCellInit();
+    bool PatchCombatDialogue();
     bool PatchConjurationEnchantAbsorbs();
     bool PatchCreateArmorNodeNullptrCrash();
     bool PatchDoublePerkApply();

--- a/src/fixes/miscfixes.cpp
+++ b/src/fixes/miscfixes.cpp
@@ -384,6 +384,41 @@ namespace fixes
         return true;
     }
 
+    class CombatDialoguePatch
+    {
+    public:
+        static void Install()
+        {
+            REL::Relocation<std::uintptr_t> target(REL::ID{ 43571 });
+            SKSE::GetTrampoline().write_call<5>(target.address() + 0x135, &Patch);
+        }
+
+    private:
+        static constexpr std::uint32_t LostToNormal = 63;
+        static constexpr std::uint32_t CombatToNormal = 61;
+
+        static void Patch(float a_unk1, RE::Actor* a_thisActor, RE::Actor* a_target, std::uint32_t a_unk4, std::uint32_t a_eventType, std::uint64_t a_unk6, void* a_unk7)
+        {
+            if (a_eventType == LostToNormal && a_target->IsDead())
+            {
+                a_eventType = CombatToNormal;
+            }
+
+            REL::Relocation<decltype(&Patch)> func(REL::ID{ 43467 });
+            return func(a_unk1, a_thisActor, a_target, a_unk4, a_eventType, a_unk6, a_unk7);
+        }
+    };
+
+    bool PatchCombatDialogue()
+    {
+        logger::trace("- combat dialogue fix -"sv);
+
+        CombatDialoguePatch::Install();
+
+        logger::trace("success"sv);
+        return true;
+    }
+
     class ConjurationEnchantAbsorbsPatch
     {
     public:


### PR DESCRIPTION
This should fix the bug that causes NPCs to use LostToNormal dialogue instead of CombatToNormal after killing their targets.
I simply added a check if the combat target is dead. If it is, CombatToNormal will be used.