### PR TITLE
1.6.629+ and GOG support

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "external/CommonLibSSE"]
-	path = external/CommonLibSSE
-	url = https://github.com/Ryan-rsm-McKenzie/CommonLibSSE

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "external/CommonLibSSE"]
+	path = external/CommonLibSSE
+	url = https://github.com/powerof3/CommonLibSSE

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -32,6 +32,7 @@ endif()
 
 add_compile_definitions(
 	SKSE_SUPPORT_XBYAK
+	SKYRIM_SUPPORT_AE
     _UNICODE
     UNICODE
 )

--- a/cmake/version.cmake
+++ b/cmake/version.cmake
@@ -1,1 +1,1 @@
-set(VERSION 6.0.2)
+set(VERSION 6.0.3)

--- a/src/PCH.h
+++ b/src/PCH.h
@@ -1,7 +1,5 @@
 #pragma once
 
-#define SKYRIM_SUPPORT_AE
-
 #include "RE/Skyrim.h"
 #include "SKSE/SKSE.h"
 

--- a/src/PCH.h
+++ b/src/PCH.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#define SKYRIM_SUPPORT_AE
+
 #include "RE/Skyrim.h"
 #include "SKSE/SKSE.h"
 

--- a/src/config.h
+++ b/src/config.h
@@ -88,7 +88,7 @@ public:
                     setting->load(table);
                 } catch (const std::exception& e)
                 {
-                    logger::warn(e.what());
+                    logger::warn("{}", e.what());
                 }
             }
         } catch (const toml::parse_error& e)
@@ -99,7 +99,7 @@ public:
                 << "\':\n"
                 << e.description()
                 << "\n  (" << e.source().begin << ")\n";
-            logger::error(ss.str());
+            logger::error("{}", ss.str());
             return false;
         }
 

--- a/src/fixes.cpp
+++ b/src/fixes.cpp
@@ -40,8 +40,8 @@ namespace fixes
         if (*config::fixConjurationEnchantAbsorbs)
             PatchConjurationEnchantAbsorbs();
 
-        if (*config::fixDoublePerkApply)
-            PatchDoublePerkApply();
+        //if (*config::fixDoublePerkApply)
+        //    PatchDoublePerkApply();
 
         if (*config::fixEquipShoutEventSpam)
             PatchEquipShoutEventSpam();

--- a/src/fixes/doubleperkapply.cpp
+++ b/src/fixes/doubleperkapply.cpp
@@ -6,9 +6,9 @@ namespace fixes
 
     typedef void (*_QueueApplyPerk)(RE::TaskQueueInterface* thisPtr, RE::Actor* actor, RE::BGSPerk* perk, std::int8_t oldRank, std::int8_t newRank);
     REL::Relocation<_QueueApplyPerk> QueueApplyPerk{ offsets::DoublePerkApply::QueueApplyPerk };
-    typedef void (*_HandleAddRf)(std::int64_t apm);
+    typedef void (*_HandleAddRf)(RE::AIProcess* apm);
     REL::Relocation<_HandleAddRf> HandleAddRf{ offsets::DoublePerkApply::Handle_Add_Rf };
-    REL::Relocation<std::uintptr_t> SwitchFunctionMovzx{ offsets::DoublePerkApply::BSTaskPool_HandleTask_Movzx, 0x2164 };
+    REL::Relocation<std::uintptr_t> SwitchFunctionMovzx{ offsets::DoublePerkApply::BSTaskPool_HandleTask_Movzx, 0x2165 };
     REL::Relocation<std::uintptr_t> UnknownAddFuncMovzx1{ offsets::DoublePerkApply::Unknown_Add_Function, 0x1A };
     REL::Relocation<std::uintptr_t> UnknownAddFuncMovzx2{ offsets::DoublePerkApply::Unknown_Add_Function, 0x46 };
     REL::Relocation<std::uintptr_t> NextFormIdGetHook{ offsets::DoublePerkApply::Next_Formid_Get_Hook, 0x1B };
@@ -31,15 +31,15 @@ namespace fixes
         QueueApplyPerk(RE::TaskQueueInterface::GetSingleton(), actorPtr, perkPtr, oldRank, newRank);
     }
 
-    void do_handle(std::int64_t actorPtr, std::uint32_t val)
+    void do_handle(RE::Actor* actorPtr, std::uint32_t val)
     {
         bool shouldClear = (val & 0x100) != 0;
 
         if (shouldClear)
         {
-            std::int64_t apm = *((std::int64_t*)(actorPtr + 0xF0));  // actorprocessmanager 0xF0 in SSE Actor
-            if (apm != 0)
-                HandleAddRf(apm);
+        // actorprocessmanager 0xF0 in SSE Actor
+            if (actorPtr->currentProcess)
+                HandleAddRf(actorPtr->currentProcess);
         }
     }
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -58,7 +58,8 @@ extern "C" DLLEXPORT constinit auto SKSEPlugin_Version = []() {
     v.PluginName(Version::NAME);
     v.AuthorName("aers"sv);
     v.CompatibleVersions({ SKSE::RUNTIME_1_6_629 });
-    v.UsesAddressLibrary(true);
+    v.UsesAddressLibrary();
+    v.UsesUpdatedStructs();
     return v;
 }();
 
@@ -131,7 +132,15 @@ extern "C" DLLEXPORT bool SKSEAPI SKSEPlugin_Load(const SKSE::LoadInterface* a_s
         return false;
 
     if (!GetModuleHandleA("steam_api64.dll"))
-        Initialize();
+    {
+        REL::Version oldSKSEVersion{ 2, 2, 2 };
+        if (a_skse->SKSEVersion() == oldSKSEVersion.pack())
+        {
+            Initialize();
+            logger::info("applied workaround for SKSE GOG loader (2.2.2)"sv);
+        }
+
+    }
 
     logger::info("beginning pre-load patches"sv);
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -62,8 +62,14 @@ extern "C" DLLEXPORT constinit auto SKSEPlugin_Version = []() {
     return v;
 }();
 
+bool initialized = false;
+
 extern "C" void DLLEXPORT APIENTRY Initialize()
 {
+    if (initialized)
+        return;
+    initialized = true;
+
 #ifdef _DEBUG
     while (!IsDebuggerPresent())
     {
@@ -123,6 +129,9 @@ extern "C" DLLEXPORT bool SKSEAPI SKSEPlugin_Load(const SKSE::LoadInterface* a_s
     const auto messaging = SKSE::GetMessagingInterface();
     if (!messaging->RegisterListener("SKSE", MessageHandler))
         return false;
+
+    if (!GetModuleHandleA("steam_api64.dll"))
+        Initialize();
 
     logger::info("beginning pre-load patches"sv);
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -57,9 +57,8 @@ extern "C" DLLEXPORT constinit auto SKSEPlugin_Version = []() {
     v.pluginVersion = Version::MAJOR;
     v.PluginName(Version::NAME);
     v.AuthorName("aers"sv);
-    v.CompatibleVersions({ SKSE::RUNTIME_LATEST });
+    v.CompatibleVersions({ SKSE::RUNTIME_1_6_629 });
     v.UsesAddressLibrary(true);
-    v.HasNoStructUse(true);
     return v;
 }();
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -45,7 +45,7 @@ void MessageHandler(SKSE::MessagingInterface::Message* a_msg)
 
 bool CheckVersion(const REL::Version& a_version)
 {
-    const auto success = a_version >= SKSE::RUNTIME_1_6_317;
+    const auto success = a_version >= SKSE::RUNTIME_1_6_629;
     if (!success)
         logger::critical("Unsupported runtime version {}"sv, a_version.string());
 
@@ -59,6 +59,7 @@ extern "C" DLLEXPORT constinit auto SKSEPlugin_Version = []() {
     v.AuthorName("aers"sv);
     v.CompatibleVersions({ SKSE::RUNTIME_LATEST });
     v.UsesAddressLibrary(true);
+    v.HasNoStructUse(true);
     return v;
 }();
 

--- a/src/offsets.h
+++ b/src/offsets.h
@@ -198,7 +198,10 @@ namespace offsets
         // E8 ? ? ? ? 48 8B 03 48 8B CB FF 90 ? ? ? ? 80 3D ? ? ? ? ?
         constexpr REL::ID Handle_Add_Rf(40027);
         // 40 55 53 56 57 41 54 41 55 41 56 41 57 48 8D AC 24 ? ? ? ? 48 81 EC ? ? ? ? 48 C7 85 ? ? ? ? ? ? ? ? 0F 29 B4 24 ? ? ? ?
+        
+        // Function modified in 1.6.629+, shift offset 1 byte
         constexpr REL::ID BSTaskPool_HandleTask_Movzx(36991);
+         
         // 48 85 D2 74 7C 48 89 5C 24 ?
         constexpr REL::ID Unknown_Add_Function(36982);
         // 48 83 EC 38 48 83 79 ? ? 74 2B
@@ -290,6 +293,7 @@ namespace offsets
     namespace SaveScreenshots
     {
         // E8 ? ? ? ? 33 C9 E8 ? ? ? ? 88 1D ? ? ? ?
+        // Function modified in 1.6.629+, unaffected
         constexpr REL::ID BGSSaveLoadManager_ProcessEvents_RequestScreenshot(35772);
         // E8 ? ? ? ? 48 8B 05 ? ? ? ? 48 8D 3D ? ? ? ? 
         constexpr REL::ID MenuSave_RequestScreenshot(36555);

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -2,6 +2,7 @@
   "name": "enginefixes",
   "version-string": "1",
   "dependencies": [
+    "tomlplusplus",
     "autotoml",
     "boost-regex",
     "boost-stl-interfaces",
@@ -9,5 +10,9 @@
     "tbb",
     "xbyak",
     "rsm-binary-io"
+  ],
+  "builtin-baseline": "9259a0719d94c402aae2ab7975bc096afdec15df",
+  "overrides": [
+    { "name": "tomlplusplus", "version": "2.3.0" }
   ]
 }


### PR DESCRIPTION
**GOG** 
- Swapped to po3 clib as it contains necessary changes to support the GOG version
- GOG loader workaround calls Initialize in SKSEPlugin_Load as this is called before the preloader.
- SKSE GOG loader workaround checks against the specific SKSE version, future SKSE versions are unaffected. 

**Changes**
- Double Perk Apply Fix was updated, but was found to not work on AE anyway, so was disabled. This should either be outright removed or fixed/replaced.
- (DoublePerkApply) _BSTaskPool_HandleTask_Movzx_ offset shifted one byte
- (DoublePerkApply) _AIProcess_ offset shifted, uses CommonLibSSE to get the correct offset
- (SaveScreenshots) _BGSSaveLoadManager_ProcessEvents_RequestScreenshot_ changed, unaffected

**Notes**
Every function ID has been checked. Only _BSTaskPool_HandleTask_Movzx_  and _BGSSaveLoadManager_ProcessEvents_RequestScreenshot_ changed. Since the mod is largely using CommonLibSSE to get offsets from pointers, the rest of the mod is theoretically fine on the latest update.