### PR TITLE
Update SaveScreenshots for 1.6.1130

### DIFF
--- a/src/fixes/savescreenshots.cpp
+++ b/src/fixes/savescreenshots.cpp
@@ -8,7 +8,7 @@ namespace fixes
     std::uint8_t screenshot_requested_location = 0;
 
     REL::Relocation<std::uintptr_t> BGSSaveLoadManager_ProcessEvents_RequestScreenshot{ offsets::SaveScreenshots::BGSSaveLoadManager_ProcessEvents_RequestScreenshot, 0x1C6 };
-    REL::Relocation<std::uintptr_t> MenuSave_RequestScreenshot{ offsets::SaveScreenshots::MenuSave_RequestScreenshot, 0x5D6 };
+    REL::Relocation<std::uintptr_t> MenuSave_RequestScreenshot{ offsets::SaveScreenshots::MenuSave_RequestScreenshot, 0x5D5 };
     REL::Relocation<std::uintptr_t> SaveScreenshotRequestedDword{ offsets::SaveScreenshots::g_RequestSaveScreenshot };
     REL::Relocation<std::uintptr_t> ScreenshotJnz{ offsets::SaveScreenshots::ScreenshotRenderFunction, 0x17D };
     REL::Relocation<std::uintptr_t> RenderTargetHook_1{ offsets::SaveScreenshots::ScreenshotRenderFunction, 0x294 };


### PR DESCRIPTION
The game was crashing while loading when TAA is disabled and SaveScreenshots=true.

The offset 36555 + 0x5D6 doesn't seems to be right anymore.

This change works for me, but can you validate ? I'm not so confident when dealing with ASM.

Crashlog before the change:

PROBABLE CALL STACK:
	[0] 0x7FF6B8D446D1 SkyrimSE.exe+06446D1 -> 36555+0x5E1	add [rax], al
	[1] 0x7FF6B8D46E2C SkyrimSE.exe+0646E2C -> 36564+0xA9C	test r15b, r15b
	[2] 0x7FF6B8D3EFC5 SkyrimSE.exe+063EFC5 -> 36544+0x165	test bl, bl
	[3] 0x7FF6B9C3348E SkyrimSE.exe+153348E -> 109636+0x106	mov ebx, eax
	[4] 0x7FFE7CE7257D KERNEL32.DLL+001257D
	[5] 0x7FFE7F10AA58    ntdll.dll+005AA58

REGISTERS:
	RAX 0x0                (size_t) [0]
	RCX 0x2717F7EB4D0      (void*)
	RDX 0x5F8              (size_t) [1528]
	RBX 0x0                (size_t) [0]
	RSP 0xD3174FF5A0       (void*)
	RBP 0x27115AC9D00      (Main*)
	RSI 0x7FF6BB86EE00     (void* -> SkyrimSE.exe+316EE00	add [rax], al)
	RDI 0x0                (size_t) [0]
	R8  0x2                (size_t) [2]
	R9  0x7FF6BBA7B1C0     (void* -> SkyrimSE.exe+337B1C0	clc)
	R10 0x0                (size_t) [0]
	R11 0xD3174FF570       (void*)
	R12 0x0                (size_t) [0]
	R13 0x768              (size_t) [1896]
	R14 0x0                (size_t) [0]
	R15 0x2717FBC6E80      (NiCamera*)
		RTTIName: "NiCamera"
		Flags: kSelectiveUpdate | kSelectiveUpdateTransforms | kSelectiveUpdateController

STACK:
	[RSP+0  ] 0x0                (size_t) [0]
	[RSP+8  ] 0x0                (size_t) [0]
	[RSP+10 ] 0x27115AC9D00      (Main*)
	[RSP+18 ] 0x7FF6BB86EE00     (void* -> SkyrimSE.exe+316EE00	add [rax], al)
	[RSP+20 ] 0x47545A700        (size_t) [19147368192]
	[RSP+28 ] 0xD3174FF620       (void*)
	[RSP+30 ] 0x2717FBC6E80      (NiCamera*)
		RTTIName: "NiCamera"
		Flags: kSelectiveUpdate | kSelectiveUpdateTransforms | kSelectiveUpdateController
	[RSP+38 ] 0xFFFFFFFFFFFFFFFE (size_t) [uint: 18446744073709551614 int: -2]
	[RSP+40 ] 0x27199F74D30      (void*)
	[RSP+48 ] 0x7FFE2D122D5E     (void* -> MSVCP140.dll+0012D5E	mov eax, [rsp+0x34])
	[RSP+50 ] 0x27115AC9D00      (Main*)
	[RSP+58 ] 0x2719B9FB2E0      (void*)
	[RSP+60 ] 0x27115A8AE80      (NiCamera*)
		Name: "WorldRoot Camera"
		RTTIName: "NiCamera"
		Flags: kSelectiveUpdate | kSelectiveUpdateTransforms | kSelectiveUpdateController
		Checking Parent: 0
			Name: "WorldRoot CameraNode"
			RTTIName: "NiNode"
			Flags: kSelectiveUpdate | kSelectiveUpdateTransforms | kSelectiveUpdateController
			Checking Parent: 0
				Name: "WorldRoot Node"
				RTTIName: "SceneGraph"
				Flags: kSelectiveUpdate | kSelectiveUpdateTransforms | kSelectiveUpdateController | kAlwaysDraw | kFixedBound
		Name: "WorldRoot Camera"