### PR TITLE
Fix stuck mouse buttons

### DIFF
--- a/Skyrim/Data/SKSE/Plugins/EngineFixes.toml
+++ b/Skyrim/Data/SKSE/Plugins/EngineFixes.toml
@@ -39,6 +39,7 @@ bRemovedSpellBook = true                        # fixes a crash where learning a
 bSaveScreenshots = true                         # fixes save screenshots being blank under certain configurations
 bSavedHavokDataLoadInit = true                  # fixes motion vectors for objects with saved havok data that differs significantly from their base state
 bShadowSceneNodeNullPtrCrash = true             # fixes a crash in shadowscenenode
+bStuckMouseButtons = true                       # fixes stuck mouse buttons when a new menu opened and the old menu didn't receive MouseUp
 bTextureLoadCrash = true                        # fixes a crash in 1.5.97 when a texture load fails (D6DDDA), this behavior is built-in to 1.6.1170; also logs texture load errors
 bTorchLandscape = true                          # fixes a bug where torches sometimes don't light the landscape
 bTreeReflections = true                         # fixes tree LOD reflection alpha

--- a/src/fixes/fixes.cpp
+++ b/src/fixes/fixes.cpp
@@ -32,6 +32,7 @@
 #include "removed_spellbook.h"
 #include "saved_havok_data_load_init.h"
 #include "shadowscenenode_nullptr_crash.h"
+#include "stuck_mouse_buttons.h"
 #include "texture_load_crash.h"
 #include "torch_landscape.h"
 #include "vertical_look_sensitivity.h"

--- a/src/fixes/stuck_mouse_buttons.h
+++ b/src/fixes/stuck_mouse_buttons.h
@@ -47,9 +47,14 @@ namespace Fixes::StuckMouseButtons
                     if (!ui)
                         return;
 
+                    RE::IMenu* openedMenu = nullptr;
+                    auto       it = ui->menuMap.find(menuName.c_str());
+                    if (it != ui->menuMap.end())
+                        openedMenu = it->second.menu.get();
+
                     for (auto& menuPtr : ui->menuStack) {
                         auto* menu = menuPtr.get();
-                        if (!menu || !menu->uiMovie || !menu->UsesCursor())
+                        if (!menu || !menu->uiMovie || !menu->UsesCursor() || menu == openedMenu)
                             continue;
 
                         float         fx = 0.0f, fy = 0.0f;
@@ -58,11 +63,6 @@ namespace Fixes::StuckMouseButtons
 
                         if (fButtons == 0)
                             continue;
-
-                        for (auto& entry : ui->menuMap) {
-                            if (entry.second.menu.get() == menu && entry.first == menuName.c_str())
-                                return;
-                        }
 
                         TrySendMouseUp(menu);
                         return;

--- a/src/fixes/stuck_mouse_buttons.h
+++ b/src/fixes/stuck_mouse_buttons.h
@@ -20,9 +20,6 @@ namespace Fixes::StuckMouseButtons
 
             static void TrySendMouseUp(RE::IMenu* a_menu)
             {
-                if (!a_menu || !a_menu->uiMovie || !a_menu->UsesCursor())
-                    return;
-
                 auto* cursor = RE::MenuCursor::GetSingleton();
                 if (!cursor)
                     return;
@@ -39,20 +36,37 @@ namespace Fixes::StuckMouseButtons
             }
 
             RE::BSEventNotifyControl ProcessEvent(
-                const RE::MenuOpenCloseEvent*              a_event,
+                const RE::MenuOpenCloseEvent* a_event,
                 RE::BSTEventSource<RE::MenuOpenCloseEvent>*) override
             {
                 if (!a_event || !a_event->opening)
                     return RE::BSEventNotifyControl::kContinue;
 
-                SKSE::GetTaskInterface()->AddTask([]() {
+                SKSE::GetTaskInterface()->AddTask([menuName = std::string(a_event->menuName.c_str())]() {
                     auto* ui = RE::UI::GetSingleton();
                     if (!ui)
                         return;
 
-                    auto& stack = ui->menuStack;
-                    if (stack.size() >= 2)
-                        TrySendMouseUp(stack[1].get());
+                    for (auto& menuPtr : ui->menuStack) {
+                        auto* menu = menuPtr.get();
+                        if (!menu || !menu->uiMovie || !menu->UsesCursor())
+                            continue;
+
+                        float         fx = 0.0f, fy = 0.0f;
+                        std::uint32_t fButtons = 0;
+                        menu->uiMovie->GetMouseState(0, &fx, &fy, &fButtons);
+
+                        if (fButtons == 0)
+                            continue;
+
+                        for (auto& entry : ui->menuMap) {
+                            if (entry.second.menu.get() == menu && entry.first == menuName.c_str())
+                                return;
+                        }
+
+                        TrySendMouseUp(menu);
+                        return;
+                    }
                 });
 
                 return RE::BSEventNotifyControl::kContinue;

--- a/src/fixes/stuck_mouse_buttons.h
+++ b/src/fixes/stuck_mouse_buttons.h
@@ -1,0 +1,68 @@
+#pragma once
+
+namespace Fixes::StuckMouseButtons
+{
+    namespace detail
+    {
+        class MenuOpenCloseEventSink : public RE::BSTEventSink<RE::MenuOpenCloseEvent>
+        {
+        public:
+            static MenuOpenCloseEventSink* GetSingleton()
+            {
+                static MenuOpenCloseEventSink singleton;
+                return &singleton;
+            }
+
+        private:
+            MenuOpenCloseEventSink() = default;
+            MenuOpenCloseEventSink(const MenuOpenCloseEventSink&) = delete;
+            MenuOpenCloseEventSink& operator=(const MenuOpenCloseEventSink&) = delete;
+
+            static void TrySendMouseUp(RE::IMenu* a_menu)
+            {
+                if (!a_menu || !a_menu->uiMovie || !a_menu->UsesCursor())
+                    return;
+
+                auto* cursor = RE::MenuCursor::GetSingleton();
+                if (!cursor)
+                    return;
+
+                RE::GFxMouseEvent mouseUp(
+                    RE::GFxEvent::EventType::kMouseUp,
+                    0,
+                    cursor->cursorPosX,
+                    cursor->cursorPosY,
+                    0.0f,
+                    0);
+
+                a_menu->uiMovie->HandleEvent(mouseUp);
+            }
+
+            RE::BSEventNotifyControl ProcessEvent(
+                const RE::MenuOpenCloseEvent*              a_event,
+                RE::BSTEventSource<RE::MenuOpenCloseEvent>*) override
+            {
+                if (!a_event || !a_event->opening)
+                    return RE::BSEventNotifyControl::kContinue;
+
+                SKSE::GetTaskInterface()->AddTask([]() {
+                    auto* ui = RE::UI::GetSingleton();
+                    if (!ui)
+                        return;
+
+                    auto& stack = ui->menuStack;
+                    if (stack.size() >= 2)
+                        TrySendMouseUp(stack[1].get());
+                });
+
+                return RE::BSEventNotifyControl::kContinue;
+            }
+        };
+    }
+
+    inline void Install()
+    {
+        RE::UI::GetSingleton()->AddEventSink(detail::MenuOpenCloseEventSink::GetSingleton());
+        logger::info("installed stuck mouse buttons fix"sv);
+    }
+}

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -6,6 +6,7 @@
 #include "fixes/bslightingshader_parallax_bug.h"
 #include "fixes/fixes.h"
 #include "fixes/save_screenshots.h"
+#include "fixes/stuck_mouse_buttons.h"
 #include "fixes/tree_reflections.h"
 #include "memory/allocator.h"
 #include "memory/memory.h"
@@ -30,6 +31,8 @@ void MessageHandler(SKSE::MessagingInterface::Message* a_msg)
             // need ini settings
             if (Settings::Fixes::bSaveScreenshots.GetValue())
                 Fixes::SaveScreenshots::Install();
+            if (Settings::Fixes::bStuckMouseButtons.GetValue())
+                Fixes::StuckMouseButtons::Install();
             // need to make sure enb dll has loaded
             if (Settings::Fixes::bTreeReflections.GetValue())
                 Fixes::TreeReflections::Install();

--- a/src/settings.h
+++ b/src/settings.h
@@ -44,6 +44,7 @@ namespace Settings
         static REX::TOML::Bool bSaveScreenshots("Fixes", "bSaveScreenshots", true);
         static REX::TOML::Bool bSavedHavokDataLoadInit("Fixes", "bSavedHavokDataLoadInit", true);
         static REX::TOML::Bool bShadowSceneNodeNullPtrCrash("Fixes", "bShadowSceneNodeNullPtrCrash", true);
+        static REX::TOML::Bool bStuckMouseButtons("Fixes", "bStuckMouseButtons", true);
         static REX::TOML::Bool bTextureLoadCrash("Fixes", "bTextureLoadCrash", true);
         static REX::TOML::Bool bTorchLandscape("Fixes", "bTorchLandscape", true);
         static REX::TOML::Bool bTreeReflections("Fixes", "bTreeReflections", true);


### PR DESCRIPTION
Fixes an issue where opening a new menu with a mouse click `MouseDown` causes the `MouseUp` event to go to the new menu, but the old menu doesn't receive the `MouseUp` event. Even when exiting the new menu, the old menu thinks the mouse is still down. Because of this, you have to manually click to get mouse focus back.
Steps to reproduce:
1) Open your inventory
2) Open Books
3) Open a book with a mouse click
4) Close the book with Tab or Esc
5) Try hovering the mouse over the books

Mouse focus won't work in this case until you click the mouse.
This problem also occurs when you hold down an item in your inventory and while the mouse is held down, press `[F]` and a hint about the Favorite Menu appears.